### PR TITLE
добавлена работа с переменными

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -41,7 +41,8 @@ const (
 
 // listCmd represents the list command
 var (
-	fullPrint bool
+	fullPrint      bool
+	printVariables bool
 
 	listCmd = &cobra.Command{
 		Use:     "list",
@@ -57,6 +58,11 @@ var (
 			if !ok {
 				fmt.Println("failed to get all aliases")
 				return
+			}
+
+			if printVariables {
+				aliases = viper.GetStringMap("vars")
+				logger.SaveDebugf("print variables")
 			}
 
 			parallelKeys := viper.GetStringMap(parallel.ParallelPrefix)
@@ -97,6 +103,10 @@ var (
 							command,
 						)
 					}
+				}
+
+				if printVariables {
+					return
 				}
 
 				for alias, commands := range parallelCommands {
@@ -180,7 +190,8 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	listCmd.Flags().BoolVarP(&fullPrint, "full", "f", false, "use fast print")
+	listCmd.Flags().BoolVarP(&fullPrint, "full", "f", false, "use full print")
+	listCmd.Flags().BoolVarP(&printVariables, "vars", "v", false, "print variables")
 }
 
 func searchInAlias(search, alias, command string) bool {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	logo    = "       _ _ \n  __ _| (_)\n / _` | | |\n| (_| | | |\n \\__,_|_|_|"
-	version = "v1.5.3-beta.2"
+	version = "v1.5.4-beta.vars.3"
 )
 
 // versionCmd represents the version command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	logo    = "       _ _ \n  __ _| (_)\n / _` | | |\n| (_| | | |\n \\__,_|_|_|"
-	version = "v1.5.4-beta.vars.3"
+	version = "v1.5.4-beta.vars.4"
 )
 
 // versionCmd represents the version command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	logo    = "       _ _ \n  __ _| (_)\n / _` | | |\n| (_| | | |\n \\__,_|_|_|"
-	version = "v1.5.4-beta.vars.4"
+	version = "v1.5.9-beta.vars"
 )
 
 // versionCmd represents the version command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	logo    = "       _ _ \n  __ _| (_)\n / _` | | |\n| (_| | | |\n \\__,_|_|_|"
-	version = "v1.5.3"
+	version = "v1.5.3-beta.2"
 )
 
 // versionCmd represents the version command

--- a/parallel/exec.go
+++ b/parallel/exec.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/algrvvv/ali/logger"
 	"github.com/algrvvv/ali/utils"
 )
 
@@ -16,7 +17,18 @@ func Exec(command Command, outputColor string, withoutOutput bool, wg *sync.Wait
 
 	commandLabel := utils.Colorize(command.Label, command.Color)
 	label := utils.Colorize(fmt.Sprintf("[%s]", command.Label), command.Color)
+
+	vars, err := utils.GetVars()
+	if err != nil {
+		logger.SaveDebugf("failed to get all vars: %v", err)
+		fmt.Println("failed to get vars. skip")
+	} else {
+		logger.SaveDebugf("got vars: %v", vars)
+		command.Command = utils.GetVariables(command.Command, vars)
+	}
+
 	fmt.Printf("Running command: %s\n", commandLabel)
+	logger.SaveDebugf("result command: %s", command.Command)
 
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {

--- a/utils/execute_alias.go
+++ b/utils/execute_alias.go
@@ -40,24 +40,36 @@ func ExecuteAlias(command string, args []string, flags map[string]string) {
 		return
 	}
 
-	var cmd *exec.Cmd
+	resultCmd := cmdArgs
+	vars, err := GetVars()
+	if err != nil {
+		logger.SaveDebugf("failed to get all vars: %v", err)
+		fmt.Println("failed to get vars. skip")
+	} else {
+		logger.SaveDebugf("got vars: %v", vars)
+		resultCmd = GetVariables(cmdArgs, vars)
+	}
 
+	logger.SaveDebugf("result command to execute: %s", resultCmd)
+
+	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "windows":
-		cmd = exec.Command("cmd.exe", "/C", cmdArgs)
+		cmd = exec.Command("cmd.exe", "/C", resultCmd)
 	case "linux", "darwin":
-		cmd = exec.Command("sh", "-c", cmdArgs)
+		cmd = exec.Command("sh", "-c", resultCmd)
 	default:
+		fmt.Println("Unsupported OS")
 		logger.SaveDebugf("Unsupported OS")
 		return
 	}
 
-	// cmd := exec.Command("sh", "-c", cmdArgs)
+	// cmd := exec.Command("sh", "-c", resultCmd)
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 
-	err := cmd.Start()
+	err = cmd.Start()
 	CheckError(err)
 
 	err = cmd.Wait()

--- a/utils/execute_alias.go
+++ b/utils/execute_alias.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/algrvvv/ali/logger"
+	"github.com/spf13/viper"
 )
 
 func ExecuteAlias(command string, args []string, flags map[string]string) {
@@ -23,6 +24,19 @@ func ExecuteAlias(command string, args []string, flags map[string]string) {
 	}
 
 	for key, value := range flags {
+		logger.SaveDebugf("got key: %s", key)
+
+		if strings.Contains(key, "V_") {
+			varToChange := strings.Replace(key, "V_", "", 1)
+			varToChange = strings.TrimLeft(varToChange, "-")
+			logger.SaveDebugf("key: %s - contains V; var to change: %s", key, varToChange)
+
+			varKey := fmt.Sprintf("vars.%s", varToChange)
+			logger.SaveDebugf("got var key for change: %s", varKey)
+			viper.Set(varKey, value)
+			continue
+		}
+
 		k := fmt.Sprintf("<%s>", strings.ReplaceAll(key, "-", ""))
 		logger.SaveDebugf("parse command for find flag: %s with value: %s", k, value)
 		if strings.Contains(command, k) {

--- a/utils/get_variables.go
+++ b/utils/get_variables.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+type varConfig struct {
+	Vars map[string]string `mapstructure:"vars"`
+}
+
+func getVars() (map[string]string, error) {
+	var vars varConfig
+
+	err := viper.Unmarshal(&vars)
+	if err != nil {
+		return nil, err
+	}
+
+	return vars.Vars, nil
+}
+
+func GetVariables(input string, vars map[string]string) string {
+	re := regexp.MustCompile(`\{\{(\w+)\}\}`)
+	return re.ReplaceAllStringFunc(input, func(match string) string {
+		// key := re.FindStringSubmatch(match)[1]
+		key := strings.ToLower(re.FindStringSubmatch(match)[1])
+		if val, ok := vars[key]; ok {
+			return val
+		}
+		return match // если переменная не найдена — не трогать
+	})
+}

--- a/utils/get_variables.go
+++ b/utils/get_variables.go
@@ -11,7 +11,7 @@ type varConfig struct {
 	Vars map[string]string `mapstructure:"vars"`
 }
 
-func getVars() (map[string]string, error) {
+func GetVars() (map[string]string, error) {
 	var vars varConfig
 
 	err := viper.Unmarshal(&vars)

--- a/utils/get_variables_test.go
+++ b/utils/get_variables_test.go
@@ -1,0 +1,35 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/algrvvv/ali/utils"
+)
+
+func TestGetVariables(t *testing.T) {
+	vars := map[string]string{
+		"EXECUTE":   "./twentyone",
+		"USER_FLAG": "--user=algrvvv",
+		"NAME":      "go run main.go",
+		"COMMAND":   "list -L",
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "{{EXECUTE}} {{USER_FLAG}}", expected: "./twentyone --user=algrvvv"},
+		{input: "{{EXECUTE}} run", expected: "./twentyone run"},
+		{input: "go run main.go {{COMMAND}}", expected: "go run main.go list -L"},
+		{input: "{{NAME}} {{COMMAND}} -f", expected: "go run main.go list -L -f"},
+		{input: "{{MISSING}} run", expected: "{{MISSING}} run"},
+	}
+
+	for _, test := range tests {
+		got := utils.GetVariables(test.input, vars)
+		if got != test.expected {
+			t.Errorf("want: %s; got: %s", test.expected, got)
+		}
+		t.Logf("SUCCESS! got: %s", got)
+	}
+}


### PR DESCRIPTION
- добавлена поддержка переменных, которые пишутся под отдельным ключом `vars`;
- добавлено использование переменных в обычных алиасах, а также в параллельных;
- методы для формирования итоговой строки с использованием переменных покрыты тестами;
- добавлена поддержка глобальных и локальных переменных;
- добавлены вывод переменных через команду `list`.

> ВАЖНО! все переменные, которые вы пишете в `vars` перед применением будут приведены к ловеру.